### PR TITLE
Add files via upload

### DIFF
--- a/OneStopRecon
+++ b/OneStopRecon
@@ -149,6 +149,54 @@ while [ "$#" -gt 0 ]; do
 				displayHelp=YES
 				shift
 				;;
+			"-gD")
+				chosenTool="gobusterDir"
+				if [ "$2" == "-f" ]; then
+					shift
+				else
+					gobusterTarget="$2"
+					gobusterWordList="$3"
+					shift
+					shift
+					shift
+				fi
+				;;
+			"-gN")
+				chosenTool="gobusterDNS"
+				if [ "$2" == "-f" ]; then
+					shift
+				else
+					gobusterTarget="$2"
+					gobusterWordList="$3"
+					shift
+					shift
+					shift
+				fi
+				;;
+			"-gV")
+				chosenTool="gobusterVHost"
+				if [ "$2" == "-f" ]; then
+					shift
+				else
+					gobusterTarget="$2"
+					gobusterWordList="$3"
+					shift
+					shift
+					shift
+				fi
+				;;
+			"-gF")
+				chosenTool="gobusterFuzz"
+				if [ "$2" == "-f" ]; then
+					shift
+				else
+					gobusterTarget="$2"
+					gobusterWordList="$3"
+					shift
+					shift
+					shift
+				fi
+				;;
 			*)
 				echo "Unkown error $chosenTool"
 				doNotRunWarning="YES"
@@ -199,6 +247,16 @@ elif [[ "$readFromFile" != "YES" ]] && [[ "$saveToFile" != "YES" ]]; then
 		Excute_All_Dorkings "-dD" $argForTool
 	elif [[ $chosenTool == "googleDorking" ]]; then
 		Excute_All_Dorkings -dG $argForTool
+	elif [[ $chosenTool == "gobusterDir" ]]; then
+		echo "target is $gobusterTarget"
+		echo "wordList is $gobusterWordList"
+		gobusterUtil "dir" $gobusterTarget $gobusterWordList
+	elif [[ $chosenTool == "gobusterDNS" ]]; then
+		gobusterUtil "dns" $gobusterTarget $gobusterWordList
+	elif [[ $chosenTool == "gobusterVHost" ]]; then
+		gobusterUtil "vhost" $gobusterTarget $gobusterWordList
+	elif [[ $chosenTool == "gobusterFuzz" ]]; then
+		gobusterUtil "fuzz" $gobusterTarget $gobusterWordList
 	elif [[ $chosenTool == "metadataExtraction" ]]; then
 		metadataUtil $argForTool
 	elif [[ $chosenTool == "googleMaps" ]]; then
@@ -212,9 +270,6 @@ elif [[ "$readFromFile" != "YES" ]] && [[ "$saveToFile" != "YES" ]]; then
 	elif [[ $chosenTool == "whoIs" ]]; then
 		whoisUtil $argForTool
 	elif [[ $chosenTool == "usernameGenerator" ]]; then
-		#echo $firstArgForTool
-		#echo $secondArgForTool
-		#echo $thirdArgForTool
 		usernameUtil $firstArgForTool $secondArgForTool $thirdArgForTool
 	fi
 elif [[ "$readFromFile" == "YES" ]] && [[ "$saveToFile" != "YES" ]]; then
@@ -244,7 +299,14 @@ elif [[ "$readFromFile" != "YES" ]] && [[ "$saveToFile" == "YES" ]];then
 		bannerGrab $argForTool $fileToSaveTo
 	elif [[ $chosenTool == "usernameGenerator" ]]; then	
 		usernameUtil $firstArgForTool $secondArgForTool $thirdArgForTool $fileToSaveTo
-		
+	elif [[ $chosentool == "gobusterDir" ]]; then
+		gobusterUtil "dir" $gobusterTarget $gobusterWordList $fileToSaveTo
+	elif [[ $chosenTool == "gobusterDNS" ]]; then
+		gobusterUtil "dns" $gobusterTarget $gobusterWordList $fileToSaveTo
+	elif [[ $chosenTool == "gobusterVHost" ]]; then
+		gobusterUtil "vhost" $gobusterTarget $gobusterWordList $fileToSaveTo
+	elif [[ $chosenTool == "gobusterFuzz" ]]; then
+		gobusterUtil "fuzz" $gobusterTarget $gobusterWordList $fileToSaveTo
 	else
 		echo "[!] The specified module cannot be output to a file"
 		echo "[*] To use the specified module, remove the \"-o\" command line option"

--- a/functionLibrary.sh
+++ b/functionLibrary.sh
@@ -90,12 +90,12 @@ googleMaps(){
         placeToOpen=""
         argArray=($1)
         for var in "${!argArray[@]}"; do
-                        if [[ $placeToOpen == "" ]]; then
-                                placeToOpen=${argArray[var]}
-                        else
-                                placeToOpen=$placeToOpen+${argArray[var]}
-                                shift
-                        fi
+        	if [[ $placeToOpen == "" ]]; then
+                     	placeToOpen=${argArray[var]}
+           	else
+         		placeToOpen=$placeToOpen+${argArray[var]}
+                     	shift
+             	fi
         done
         urlAppend="/"
         completeUrl=$urlPrepend$placeToOpen$urlAppend
@@ -217,23 +217,23 @@ usernameGenerator(){
 	echo ""
 }
 
-gobusterMode(){
-gobusterMode=$1
-target=$2
-wordlist=$3
+gobusterFunc(){
+	chosenMode=$1
+	target=$2
+	wordlist=$3
 
-echo "[*] Executing gobuster"
-echo "[*] Enumarating data for $target"
-echo "===================Extracted Gobuster Infomation For $target==================="
-if [[ $gobusterMode == "dir" ]]; then 
-        gobuster dir -u $target -w $wordlist #--wildcard
-elif [[ $gobusterMode == "dns" ]]; then 
-        gobuster dns -d $target -w $wordlist -t 250 
-elif [[ $gobusterMode == "vhost" ]]; then 
-        gobuster vhost -u $target -w $wordlist
-elif [[ $gobusterMode == "fuzz" ]]; then 
-        pram="?FUZZ="
-        gobuster fuzz -u $target$pram -w $wordlist 
-fi
+	echo "[*] Executing gobuster"
+	echo "[*] Enumarating data for $target"
+	echo "===================Extracted Gobuster Infomation For $target==================="
+	if [[ $gobusterMode == "dir" ]]; then 
+		"${binPath}gobuster" dir -u $target -w $wordlist #--wildcard
+	elif [[ $gobusterMode == "dns" ]]; then 
+		"${binPath}gobuster" dns -d $target -w $wordlist -t 250 
+	elif [[ $gobusterMode == "vhost" ]]; then 
+		"${binPath}gobuster" vhost -u $target -w $wordlist
+	elif [[ $gobusterMode == "fuzz" ]]; then 
+		param="?FUZZ="
+		"${binPath}gobuster" fuzz -u $target$param -w $wordlist 
+	fi
 }
 

--- a/util.sh
+++ b/util.sh
@@ -39,17 +39,17 @@ elif [ $# -gt 1 ]; then
 fi
 }
 
-usernameUtil(){
+function usernameUtil(){
 	file_ext="$(echo "$1" | /usr/bin/grep -Eo ".txt")"
 
 	if [ $# -eq 1 ]; then
 		#reading from file, output to terminal
 		#tbc once file format confirmed
-		echo "Placeholder"
+		:
 	elif [ "$#" -eq 2 ]; then
 		#reading from file, outputting to file
 		#tbc once file format confirmed
-		echo "Placeholder 2"
+		:
 	elif [ "$#" -eq 3 ]; then
 		#read from terminal, output to terminal
 		usernameGenerator $1 $2 $3
@@ -128,7 +128,6 @@ fi
 }
 
 
-
 function metadataUtil(){
 if [ "$#" -gt 1 ]; then
 	fileName=($1)
@@ -144,8 +143,8 @@ fi
 #          echo "[!]Analysing Complete" 	    
 }
 
-function bannerGrabbingUtil(){
 
+function bannerGrabbingUtil(){
 bannerGrabbingInput=$1
 file_ext="$(echo "$bannerGrabbingInput" | /usr/bin/grep -Eo ".txt" )"
 if [ $# -eq 1 ]; then 
@@ -176,6 +175,24 @@ else
 fi
 }
 
+
+function gobusterUtil(){
+mode="$1"
+target="$2"
+wordList="$3"
+fileToSaveTo="$4"
+
+if [ "$#" -eq 3 ]; then
+	gobusterFunc $mode $target $wordList
+elif [ "$#" -eq 4 ]; then
+	gobusterFunc $mode $target $wordList >> $fileToSaveTo
+else
+	echo "[!] Unexpected error occured. Please try again"
+	echo "For help, enter \"--help\""
+fi
+
+
+}
 
 
 #function Testing


### PR DESCRIPTION
Amended OneStopRecon to contain command line switches for all 4 gobuster modes/options
Amended main execution flow section to include all 4 gobuster modes/options, both for reading/outputting to terminal and reading from terminal/outputting to file
Added a new function to util.sh for gobuster to determine whether to output to terminal or file
Testing completed on all the above

Need to troubleshoot 301 error relating to gobuster dir mode (-gD command line switch in the tool). Error is with the gobuster module, not code written for OneStopRecon, MC has commented out the --wildcard switch